### PR TITLE
Make TerminalType a parameter and default to xterm

### DIFF
--- a/Functions/Public/Merge-PSPuTTYTheme.ps1
+++ b/Functions/Public/Merge-PSPuTTYTheme.ps1
@@ -7,7 +7,7 @@ function Merge-PSPuTTYTheme {
 
     .Parameter SessionName
     The name of the PuTTY saved session that will have its theme updated.
-    
+
     NOTE: The session name will be URL-encoded, to conform to the stored value in the registry. Make sure that you do not use the URL-encoded name of the session.
           Rather, use the "friendly name" of the session, that appears in the PuTTY Saved Session list.
 
@@ -31,6 +31,7 @@ function Merge-PSPuTTYTheme {
       , [Parameter(Mandatory = $true, ParameterSetName = 'SessionNameThemeObject')]
         [Parameter(Mandatory = $true, ParameterSetName = 'SessionObjectThemeObject')]
         [PSPuTTYTheme] $Theme
+      , [string] $TerminalType = 'xterm'
     )
 
     Write-Verbose -Message ('Using parameter set: {0}' -f $PSCmdlet.ParameterSetName)
@@ -56,5 +57,5 @@ function Merge-PSPuTTYTheme {
       $PuTTYSessionReg.SetValue("Colour$Number", $Theme."Colour$Number", [Microsoft.Win32.RegistryValueKind]::String)
     }
 
-    $PuTTYSessionReg.SetValue('TerminalType', 'putty-256color')
+    $PuTTYSessionReg.SetValue('TerminalType', $TerminalType)
 }


### PR DESCRIPTION
This addresses issue #6.

I've made TerminalType an optional parameter, which defaults to 'xterm', so that it can be set to whatever the user needs.

Ideally, I'd like to autocomplete a list of valid terminal types... but I wasn't able to find a way to enumerate them. I get the feeling it's the sort of thing that if you're setting it to something other than the default that you probably know what to set it to.

Eventually it'd pay to add a switch to preserve the existing terminal type, it's just a matter of making this user friendly with the parameter sets.