### PR TITLE
Add default theme

### DIFF
--- a/Themes/Default.json
+++ b/Themes/Default.json
@@ -1,0 +1,28 @@
+﻿{
+  "Name": "Solarized Light",
+  "Url": "http://putty.org.ru/themes/solarized-light.html",
+  "Colors": {
+    "Colour0": "187,187,187",
+    "Colour1": "255,255,255",
+    "Colour2": "0,0,0",
+    "Colour3": "85,85,85",
+    "Colour4": "0,0,0",
+    "Colour5": "0,255,0",
+    "Colour6": "0,0,0",
+    "Colour7": "85,85,85",
+    "Colour8": "187,0,0",
+    "Colour9": "255,85,85",
+    "Colour10": "0,187,0",
+    "Colour11": "85,255,85",
+    "Colour12": "187,187,0",
+    "Colour13": "255,255,85",
+    "Colour14": "0,0,187",
+    "Colour15": "85,85,255",
+    "Colour16": "187,0,187",
+    "Colour17": "255,85,255",
+    "Colour18": "0,187,187",
+    "Colour19": "85,255,255",
+    "Colour20": "187,187,187",
+    "Colour21": "255,255,255"
+  }
+}

--- a/Themes/Default.json
+++ b/Themes/Default.json
@@ -1,6 +1,6 @@
 ﻿{
-  "Name": "Solarized Light",
-  "Url": "http://putty.org.ru/themes/solarized-light.html",
+  "Name": "Default",
+  "Url": "https://www.chiark.greenend.org.uk/~sgtatham/putty/",
   "Colors": {
     "Colour0": "187,187,187",
     "Colour1": "255,255,255",


### PR DESCRIPTION
Being able to set a theme is great, but I couldn't see any way to "remove" a theme to go back to the standard default. I've added a `Default` theme which sets the colours to the original, standard, default values. Note that this uses the base, out-of-the box colours - if someone has made changes to their Default session, this will ignore that - it doesn't attempt to do anything fancy like find out what the user's current default colours are