### PR TITLE
Remove unimplemented functions

### DIFF
--- a/PSPuTTY.psd1
+++ b/PSPuTTY.psd1
@@ -66,11 +66,11 @@ FormatsToProcess = @(
 # Functions to export from this module
 FunctionsToExport = @(
     'Invoke-PSPuTTYSession'
-    'New-PSPuTTYSession'
+    #'New-PSPuTTYSession'
     'Get-PSPuTTYSession'
     'Get-PSPuTTYTheme'
     'Merge-PSPuTTYTheme'
-    'Remove-PSPuTTYSession'
+    #'Remove-PSPuTTYSession'
     );
 
 # Cmdlets to export from this module

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get-PSPuTTYTheme
 Merge-PSPuTTYTheme -SessionName 'AWS Ubuntu 16 Large' -ThemeName 'Birds of Paradise'
 ```
 
-## Create a new PuTTY Session
+## Create a new PuTTY Session (Not Implemented)
 
 If you want to create or import an array of PuTTY sessions, you can use `PSPuTTY` to achieve this.
 Using the simple `New-PSPuTTYSession` command, you can create a new saved session and easily access it from PuTTY at any time.
@@ -35,7 +35,7 @@ The `Invoke-PSPuTTYSession` provides Intellisense / auto-completion for your PuT
 Invoke-PSPuTTYSession -Name 'AWS Ubuntu'
 ```
 
-## Remove a PuTTY Session
+## Remove a PuTTY Session (Not Implemented)
 
 You can automate the cleanup of your PuTTY saved sessions by using the `Remove-PSPuTTYSession` command.
 When you specify one or more sessions that you want to delete, you'll be prompted with Intellisense / auto-completion for the saved session names.

--- a/Tests/PSPuTTY.tests.ps1
+++ b/Tests/PSPuTTY.tests.ps1
@@ -34,13 +34,13 @@ describe -Name 'PSPuTTY PowerShell module' {
 			(Get-Command -Module $ModuleName -Name Invoke-PSPuTTYSession).Count | Should be 1
 		}
 
-		it 'Should have a New-PSPuTTYSession command' {
-			(Get-Command -Module $ModuleName -Name New-PSPuTTYSession).Count | Should be 1
-		}
+		#it 'Should have a New-PSPuTTYSession command' {
+		#	(Get-Command -Module $ModuleName -Name New-PSPuTTYSession).Count | Should be 1
+		#}
 
-		it 'Should have a Remove-PSPuTTYSession command' {
-			(Get-Command -Module $ModuleName -Name Remove-PSPuTTYSession).Count | Should be 1
-		}
+		#it 'Should have a Remove-PSPuTTYSession command' {
+		#	(Get-Command -Module $ModuleName -Name Remove-PSPuTTYSession).Count | Should be 1
+		#}
 	}
 
 	context -Name 'Get-PSPuTTYTheme' {
@@ -61,9 +61,9 @@ describe -Name 'PSPuTTY PowerShell module' {
 		}
 	}
 
-	context -Name 'Remove-PSPuTTYSession' -Fixture {
-		it 'Should require input parameters' {
-			{ Start-Job -ScriptBlock { } } | Should throw
-		}
-	}
+	#context -Name 'Remove-PSPuTTYSession' -Fixture {
+	#	it 'Should require input parameters' {
+	#		{ Start-Job -ScriptBlock { } } | Should throw
+	#	}
+	#}
 }


### PR DESCRIPTION
Prevent the manifest exporting the functions that aren't yet implemented and add further clarification to the README

Fixes: #9